### PR TITLE
Add initial required TCK test, move others to optional

### DIFF
--- a/tck/src/test/java/org/eclipse/microprofile/jwt/bridge/tck/TCKConstants.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/bridge/tck/TCKConstants.java
@@ -24,10 +24,10 @@ public class TCKConstants {
     public static final String TEST_GROUP_UTILS = "utils";
     public static final String TEST_GROUP_UTILS_EXTRA = "utils-extra";
     public static final String TEST_GROUP_JAXRS = "jaxrs";
-    public static final String TEST_GROUP_EJB = "ejb";
-    public static final String TEST_GROUP_SERVLET = "servlet";
-    public static final String TEST_GROUP_EE_SECURITY = "ee-security";
-    public static final String TEST_GROUP_JACC = "jacc";
+    public static final String TEST_GROUP_EJB = "ejb-optional";
+    public static final String TEST_GROUP_SERVLET = "servlet-optional";
+    public static final String TEST_GROUP_EE_SECURITY = "ee-security-optional";
+    public static final String TEST_GROUP_JACC = "jacc-optional";
     // The expected JWT iss value
     public static final String TEST_ISSUER = "https://server.example.com";
 

--- a/tck/src/test/java/org/eclipse/microprofile/jwt/bridge/tck/TCKConstants.java
+++ b/tck/src/test/java/org/eclipse/microprofile/jwt/bridge/tck/TCKConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2024 Contributors to the Eclipse Foundation
  *
  *  See the NOTICE file(s) distributed with this work for additional
  *  information regarding copyright ownership.
@@ -23,6 +23,7 @@ public class TCKConstants {
     // TestNG groups
     public static final String TEST_GROUP_UTILS = "utils";
     public static final String TEST_GROUP_UTILS_EXTRA = "utils-extra";
+    public static final String TEST_GROUP_JAXRS = "jaxrs";
     public static final String TEST_GROUP_EJB = "ejb";
     public static final String TEST_GROUP_SERVLET = "servlet";
     public static final String TEST_GROUP_EE_SECURITY = "ee-security";

--- a/tck/src/test/resources/suites/tck-base-suite.xml
+++ b/tck/src/test/resources/suites/tck-base-suite.xml
@@ -20,6 +20,7 @@
         <groups>
             <define name="base-groups">
                 <include name="utils" description="Utility tests" />
+                <include name="jaxrs" description="JAX-RS invocation tests" />
                 <include name="ejb" description="EJB container integration tests" />
                 <include name="servlet" description="Servlet container integration tests" />
                 <include name="ee-security" description="Java EE security feature tests" />

--- a/tck/src/test/resources/suites/tck-base-suite.xml
+++ b/tck/src/test/resources/suites/tck-base-suite.xml
@@ -21,10 +21,6 @@
             <define name="base-groups">
                 <include name="utils" description="Utility tests" />
                 <include name="jaxrs" description="JAX-RS invocation tests" />
-                <include name="ejb" description="EJB container integration tests" />
-                <include name="servlet" description="Servlet container integration tests" />
-                <include name="ee-security" description="Java EE security feature tests" />
-                <include name="jacc" description="JACC API integration tests" />
             </define>
             <define name="excludes">
                 <include name="utils-extra" description="Additional utility tests" />
@@ -39,11 +35,7 @@
             <class name="org.eclipse.microprofile.jwt.bridge.tck.util.TokenUtilsEncryptTest" />
             <class name="org.eclipse.microprofile.jwt.bridge.tck.util.TokenUtilsSignEncryptTest" />
             <class name="org.eclipse.microprofile.jwt.bridge.tck.util.TokenUtilsExtraTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.ejb.EjbTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.servlet.ServletTest" />
             <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jaxrs.RolesAllowedTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jacc.SubjectTest" />
         </classes>
     </test>
 

--- a/tck/src/test/resources/suites/tck-full-suite.xml
+++ b/tck/src/test/resources/suites/tck-full-suite.xml
@@ -20,6 +20,7 @@
         <groups>
             <define name="base-groups">
                 <include name="utils" description="Utility tests" />
+                <include name="jaxrs" description="JAX-RS invocation tests" />
                 <include name="ejb" description="EJB container integration tests" />
                 <include name="servlet" description="Servlet container integration tests" />
                 <include name="ee-security" description="Java EE security feature tests" />

--- a/tck/src/test/resources/suites/tck-full-suite.xml
+++ b/tck/src/test/resources/suites/tck-full-suite.xml
@@ -21,10 +21,6 @@
             <define name="base-groups">
                 <include name="utils" description="Utility tests" />
                 <include name="jaxrs" description="JAX-RS invocation tests" />
-                <include name="ejb" description="EJB container integration tests" />
-                <include name="servlet" description="Servlet container integration tests" />
-                <include name="ee-security" description="Java EE security feature tests" />
-                <include name="jacc" description="JACC API integration tests" />
             </define>
             <define name="excludes">
                 <include name="utils-extra" description="Additional utility tests" />
@@ -39,12 +35,32 @@
             <class name="org.eclipse.microprofile.jwt.bridge.tck.util.TokenUtilsEncryptTest" />
             <class name="org.eclipse.microprofile.jwt.bridge.tck.util.TokenUtilsSignEncryptTest" />
             <class name="org.eclipse.microprofile.jwt.bridge.tck.util.TokenUtilsExtraTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.ejb.EjbTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.servlet.ServletTest" />
             <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jaxrs.RolesAllowedTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
-            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jacc.SubjectTest" />
         </classes>
+    </test>
+    <test name="extended-tests" verbose="10">
+        <groups>
+            <define name="extended-groups">
+                <include name="ejb-optional" description="EJB container integration tests" />
+                <include name="jacc-optional" description="JACC API integration tests" />
+                <include name="servlet-optional" description="Servlet container integration tests" />
+                <include name="ee-security-optional" description="Java EE security feature tests" />
+            </define>
+            <define name="excludes">
+                <include name="utils-extra" description="Additional utility tests" />
+            </define>
+            <run>
+                <include name="extended-groups" />
+                <exclude name="excludes" />
+            </run>
+        </groups>
+        <classes>
+            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.ejb.EjbTest" />
+            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jacc.SubjectTest" />
+            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.servlet.ServletTest" />
+            <class name="org.eclipse.microprofile.jwt.bridge.tck.container.jaxrs.jwe.RolesAllowedSignEncryptTest" />
+        </classes>
+
     </test>
 
 </suite>


### PR DESCRIPTION
Adds the first minimal required TCK test - `RolesAllowedTest.callEcho()`. I believe this is just about the simplest test in the MP JWT Auth TCK, so should be a good basic test to start with.

I also moved the other TCK tests I already delivered so that they'd be considered optional again.